### PR TITLE
Vtuhandler

### DIFF
--- a/pydata/vtuhandler.py
+++ b/pydata/vtuhandler.py
@@ -8,8 +8,7 @@
 """
 from vtk import vtkXMLUnstructuredGridReader, vtkXMLUnstructuredGridWriter
 from vtk import vtkUnstructuredGrid, vtkPoints, vtkCellArray
-from vtk import vtkGeometryFilter
-from vtk import VTK_POLYGON
+from vtk import VTK_TETRA
 
 from vtk.util.numpy_support import vtk_to_numpy, numpy_to_vtk
 
@@ -27,22 +26,18 @@ class VTUHandler(VTKHandler):
     @classmethod
     def _polydata_from_file(cls, filename):
         """
-        Private method to extract vtkPolyData from `filename`. The `filename`
+        Private method to extract vtkTetraData from `filename`. The `filename`
         have to be well-formatted VTU file.
 
         :param str filename: the name of the file to parse.
         :return: the dataset
-        :rtype: vtkPolyData
+        :rtype: vtkTetraData
         """
         reader = cls._reader_()
         reader.SetFileName(filename)
         reader.Update()
 
-        geometryFilter = vtkGeometryFilter()
-        geometryFilter.SetInputData(reader.GetOutput())
-        geometryFilter.Update()
-
-        return geometryFilter.GetOutput()
+        return reader.GetOutput()
 
     @classmethod
     def write(cls, filename, data):
@@ -54,7 +49,7 @@ class VTUHandler(VTKHandler):
         :param str filename: the name of the file to write.
         :param dict data: the dataset to save.
 
-        .. warning:: all the cells will be stored as VTK_POLYGON.
+        .. warning:: all the cells will be stored as VTK_TETRA.
             
         """
 
@@ -80,7 +75,7 @@ class VTUHandler(VTKHandler):
                 unstructured_grid.GetCellData().AddArray(vtu_array)
 
         unstructured_grid.SetPoints(points)
-        unstructured_grid.SetCells(VTK_POLYGON, cells)
+        unstructured_grid.SetCells(VTK_TETRA, cells)
 
         writer = cls._writer_()
         writer.SetFileName(filename)

--- a/pydata/vtuhandler.py
+++ b/pydata/vtuhandler.py
@@ -65,8 +65,19 @@ class VTUHandler(VTKHandler):
 
         cells = vtkCellArray()
         for cell in data['cells']:
-
             cells.InsertNextCell(len(cell), cell)
+
+        if 'point_data' in data:
+            for name, array in data['point_data'].items():
+                vtu_array = numpy_to_vtk(array)
+                vtu_array.SetName(name)
+                unstructured_grid.GetPointData().AddArray(vtu_array)
+
+        if 'cell_data' in data:
+            for name, array in data['cell_data'].items():
+                vtu_array = numpy_to_vtk(array)
+                vtu_array.SetName(name)
+                unstructured_grid.GetCellData().AddArray(vtu_array)
 
         unstructured_grid.SetPoints(points)
         unstructured_grid.SetCells(VTK_POLYGON, cells)


### PR DESCRIPTION
I think that for this type of file `VTU` whose internal mesh we want to display we need a `tetradata` instead of a `polydata`. So `VTK_TETRA` should be imported instead of `VTK_POLYGON` and used in the `write()` method as `unstructured_grid.SetCells(VTK_TETRA, cells)`. Moreover, only by removing the geometric filter is it possible to correctly display the internal mesh on the paraview by sectioning it, for example, with a slice.